### PR TITLE
Feat : 리팩토링 완료

### DIFF
--- a/src/api/TodoAxios.js
+++ b/src/api/TodoAxios.js
@@ -1,18 +1,17 @@
 import axios from 'axios';
 import { API } from '../config';
 
-const access_token = localStorage.getItem('token');
-const config = {
-  headers: { Authorization: 'Bearer ' + access_token },
-};
+const access_token = () => localStorage.getItem('token');
 
 export const TodoAxios = {
   GET: async (navigate, setTodos) => {
-    if (!access_token) {
+    const config = {
+      headers: { Authorization: 'Bearer ' + access_token() },
+    };
+    if (!access_token()) {
       navigate('/');
     } else {
       try {
-        console.log('1231');
         const { data } = await axios.get(API.Todo, config);
         setTodos(data);
       } catch (err) {
@@ -21,6 +20,9 @@ export const TodoAxios = {
     }
   },
   ADD: async todoInput => {
+    const config = {
+      headers: { Authorization: 'Bearer ' + access_token() },
+    };
     const { data } = await axios.post(
       API.Todo,
       {
@@ -33,10 +35,16 @@ export const TodoAxios = {
   },
 
   PUT: async (checkedId, todo, isCompleted) => {
+    const config = {
+      headers: { Authorization: 'Bearer ' + access_token() },
+    };
     await axios.put(`${API.Todo}/${checkedId}`, { todo, isCompleted }, config);
   },
 
   DELETE: async checkedId => {
+    const config = {
+      headers: { Authorization: 'Bearer ' + access_token() },
+    };
     await axios.delete(`${API.Todo}/${checkedId}`, config);
   },
 };

--- a/src/index.js
+++ b/src/index.js
@@ -3,11 +3,12 @@ import ReactDOM from 'react-dom/client';
 import { ThemeProvider } from 'styled-components';
 import GlobalStyle from './styles/GlobalStyle';
 import theme from './styles/theme';
+import variables from './styles/variables';
 import Router from './Router';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
-  <ThemeProvider theme={theme}>
+  <ThemeProvider theme={{ style: theme, variables }}>
     <GlobalStyle />
     <Router />
   </ThemeProvider>

--- a/src/pages/auth/Auth.js
+++ b/src/pages/auth/Auth.js
@@ -54,7 +54,7 @@ const Auth = ({ isSelectSignUp, contents }) => {
     if (localStorage.getItem('token')) {
       navigate('/todo');
     }
-  }, []);
+  }, [navigate]);
 
   return (
     <Layout>
@@ -105,20 +105,13 @@ const BackgroundColor = styled.div`
 `;
 
 const LayoutCenter = styled.div`
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
+  ${props => props.theme.variables.absoluteCenter}
 `;
 
 const LoginBox = styled.div`
   width: 500px;
   height: auto;
-  border: 1px #ababab solid;
-  border-radius: 17px;
-  &:hover {
-    box-shadow: 1px 1px 20px #ddd;
-  }
+  ${props => props.theme.variables.backGroundHover}
 `;
 
 const LoginText = styled.div`
@@ -153,7 +146,7 @@ const LoginPassword = styled.input`
 const LoginButton = styled.button`
   width: 350px;
   height: 40px;
-  background-color: #2087c9;
+  background-color: ${props => props.theme.style.mainBlue};
   color: #ffffff;
   border: none;
   border-radius: 5.5px;
@@ -169,7 +162,7 @@ const LoginButton = styled.button`
 const ToGoButton = styled.button`
   width: 350px;
   height: 40px;
-  background-color: #2087c9;
+  background-color: ${props => props.theme.style.mainBlue};
   color: #ffffff;
   border: none;
   border-radius: 5.5px;

--- a/src/pages/todo/Todo.js
+++ b/src/pages/todo/Todo.js
@@ -12,23 +12,33 @@ const Todo = ({
 }) => {
   const { id, todo, isCompleted } = todoItem;
   const [toogle, setToogle] = useState(false);
-  const valueRef = useRef('');
   const statusModify = toogle ? '제출' : '수정';
   const statusDelete = toogle ? '취소' : '삭제';
+  const Ref = useRef([]);
 
   const inputProps = !toogle
     ? { readOnly: true }
     : { onChange: e => UpdateValue(e, id) };
 
   const TodoModifyProps = !toogle
-    ? { onClick: () => setToogle(true) }
-    : { onClick: e => TodoModify(e, id, setToogle, valueRef, todo) };
+    ? {
+        onClick: () => {
+          setToogle(true);
+          Ref.current[0] = isCompleted;
+          Ref.current[1] = todo;
+        },
+      }
+    : {
+        onClick: e => {
+          TodoModify(e, id, setToogle, todo);
+        },
+      };
 
   const TodoDeleteProps = !toogle
     ? { onClick: e => TodoDelete(e, id, setToogle) }
     : {
         onClick: e => {
-          TodoChange(e, id, setToogle);
+          TodoChange(e, id, setToogle, Ref);
         },
       };
 
@@ -50,10 +60,9 @@ const Todo = ({
 export default Todo;
 
 const TodoLayout = styled.div`
-  display: flex;
-  align-items: center;
-  font-size: 20px;
+  ${props => props.theme.variables.flex()};
   margin-bottom: 10px;
+  font-size: 20px;
 `;
 
 const TodoCheck = styled.input`
@@ -63,8 +72,7 @@ const TodoCheck = styled.input`
 `;
 
 const TodoInput = styled.input`
-  display: flex;
-  align-items: center;
+  ${props => props.theme.variables.flex()};
   width: 280px;
   height: 40px;
   border: none;
@@ -75,7 +83,7 @@ const TodoModifyButton = styled.button`
   width: 50px;
   height: 40px;
   margin-left: 10px;
-  background-color: #2087c9;
+  background-color: ${props => props.theme.style.mainBlue};
   color: #ffffff;
   border: none;
   border-radius: 5.5px;

--- a/src/pages/todo/Todos.js
+++ b/src/pages/todo/Todos.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import { React, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useState } from 'react';
 import styled from 'styled-components';
@@ -10,6 +10,10 @@ const Todos = () => {
   const [todos, setTodos] = useState([]);
 
   const navigate = useNavigate();
+
+  useEffect(() => {
+    TodoAxios.GET(navigate, setTodos);
+  }, [navigate]);
 
   const onChangeTodo = e => setTodoInput(e.target.value);
 
@@ -58,14 +62,20 @@ const Todos = () => {
     alert('삭제 완료');
   };
 
-  const TodoChange = (e, setToogle) => {
+  const TodoChange = (e, checkedId, setToogle, Ref) => {
     e.preventDefault();
+    setTodos(prev =>
+      prev.map(({ id, userId, isCompleted, todo }) => {
+        if (id === checkedId) {
+          isCompleted = Ref.current[0];
+          todo = Ref.current[1];
+          Ref.current[1] = '';
+        }
+        return { id, userId, isCompleted, todo };
+      })
+    );
     setToogle(pre => !pre);
   };
-
-  useEffect(() => {
-    TodoAxios.GET(navigate, setTodos);
-  }, []);
 
   return (
     <Layout>
@@ -113,20 +123,13 @@ const BackgroundColor = styled.div`
 `;
 
 const LayoutCenter = styled.div`
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
+  ${props => props.theme.variables.absoluteCenter}
 `;
 
 const TodoBox = styled.div`
   width: 500px;
   height: auto;
-  border: 1px #ababab solid;
-  border-radius: 17px;
-  &:hover {
-    box-shadow: 1px 1px 20px #ddd;
-  }
+  ${props => props.theme.variables.backGroundHover}
 `;
 
 const TodoText = styled.div`
@@ -137,16 +140,12 @@ const TodoText = styled.div`
 `;
 
 const TodoForm = styled.div`
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-  align-items: center;
+  ${props => props.theme.variables.flex('column')}
   margin: 70px 30px;
 `;
 
 const TodoInputBox = styled.form`
-  display: flex;
-  justify-content: space-between;
+  ${props => props.theme.variables.flex()}
 `;
 
 const TodoInput = styled.input`
@@ -160,7 +159,7 @@ const TodoButton = styled.button`
   width: 50px;
   height: 40px;
   margin-left: 10px;
-  background-color: #2087c9;
+  background-color: ${props => props.theme.style.mainBlue};
   color: #ffffff;
   border: none;
   border-radius: 5.5px;

--- a/src/styles/variables.js
+++ b/src/styles/variables.js
@@ -21,6 +21,14 @@ const variables = {
     left: 50%;
     transform: translate(-50%, -50%);
   `,
+
+  backGroundHover: css`
+    border: 1px #ababab solid;
+    border-radius: 17px;
+    &:hover {
+      box-shadow: 1px 1px 20px #ddd;
+    }
+  `,
 };
 
 export default variables;


### PR DESCRIPTION
**style-Components**

반복해서 쓰이는 코드를 variables.js, theme.js 를 사용해 재사용하였습니다.

</br>
</br>

**auth** 

회원가입 / 로그인 API 모두 response로 token을 받아온다는 점을 이용해 fetch를 하나로 합쳤습니다.

</br>
</br>

**todo**

TodoList.js 는 Todo.js 와 Todos.js 중간에서 props만 넘겨주는 역할을 하기 때문에 Todos.js 에서 바로 props를 넘겨줄 수 있게끔 삭제하였습니다.

Todos.js 에서 쓰이는 axios 를 한 컴포넌트에서 관리할 수 있도록 src 폴더 안에 API 폴더를 만들어, TodoAxios.js로 분리했습니다.

수정 기능 : 취소 버튼을 누르면 수정모드에서 입력했던 값과 check 값 모두 전 상태로 돌아갈 수 있도록 useRef를 사용해 다시 리팩토링하였습니다.

삭제 기능 : 삭제 후 location.reload()로 다시 랜더링 불러오는 로직에서 삭제한 todo를 제외한 나머지 todo 리스트를 불러오는 방식으로 hook을 일으키는 방향으로 리팩토링하였습니다.

</br>
</br>


**어려웠던 점**

auth 페이지, todo 페이지에서 각각 useEffect를 사용해 token이 없다면 로그인 페이지로, token이 있다면 todo 페이지로 가는 기능을 구현했는데 리팩토링 도중

TodoAxios.js 에서 전역변수로 둔 

`const access_token = localstorage.getItem('token')`

가 token이 localstorage에 들어오기 전에 읽혀 todo 페이지에 접근할 수 없는 블로커가 있었습니다.


이는 todo 데이터를 TodoAxios.js 가 아닌 todos.js 에서 받는 방식으로도 기능이 작동되는 해결책이 있었으나
TodoAxios.js 에서의 access_token은 여전히 null 값으로 확인해

TodoAxios.js 에서의 

`const access_token = localstorage.getItem('token')`

를

`const access_token = () => localstorage.getItem('token')` 


함수형으로 바꾸어 axios 안에서 불러오도록 리팩토링하였습니다.

아쉬운 점이 있다면 전역에 헤더(access_token)을 담은 변수도 axios 안에 넣어주어야했는데
코드량이 늘어나, 어느 것이 효율적인 방법인지 고민하게 되었습니다.



